### PR TITLE
OR-506 inactivate bedrock build in docker

### DIFF
--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -39,7 +39,7 @@ COPY packages/actor-tests/package.json ./packages/actor-tests/package.json
 COPY packages/core-utils/package.json ./packages/core-utils/package.json
 COPY packages/common-ts/package.json ./packages/common-ts/package.json
 COPY packages/contracts/package.json ./packages/contracts/package.json
-COPY packages/contracts-bedrock/package.json ./packages/contracts-bedrock/package.json
+#COPY packages/contracts-bedrock/package.json ./packages/contracts-bedrock/package.json
 COPY packages/contracts-periphery/package.json ./packages/contracts-periphery/package.json
 COPY packages/contracts-governance/package.json ./packages/contracts-governance/package.json
 COPY packages/data-transport-layer/package.json ./packages/data-transport-layer/package.json
@@ -58,25 +58,25 @@ COPY ./integration-tests ./integration-tests
 # build it!
 RUN yarn build
 
-FROM base as actor-tests-bedrock
-WORKDIR /opt/optimism/packages/actor-tests
-ENTRYPOINT ["yarn", "run:bedrock"]
+#FROM base as actor-tests-bedrock
+#WORKDIR /opt/optimism/packages/actor-tests
+#ENTRYPOINT ["yarn", "run:bedrock"]
 
 FROM base as deployer
 WORKDIR /opt/optimism/packages/contracts
 COPY ./ops/scripts/deployer.sh .
 CMD ["yarn", "run", "deploy"]
 
-FROM alpine:3.16.2 as contract-artifacts-bedrock
-RUN mkdir -p /artifacts
-WORKDIR /artifacts
-COPY --from=base /opt/optimism/packages/contracts-bedrock/artifacts  /artifacts/contracts-bedrock
-COPY --from=base /opt/optimism/packages/contracts-governance/artifacts  /artifacts/contracts-governance
-CMD ["echo", "0"]
+#FROM alpine:3.16.2 as contract-artifacts-bedrock
+#RUN mkdir -p /artifacts
+#WORKDIR /artifacts
+#COPY --from=base /opt/optimism/packages/contracts-bedrock/artifacts  /artifacts/contracts-bedrock
+#COPY --from=base /opt/optimism/packages/contracts-governance/artifacts  /artifacts/contracts-governance
+#CMD ["echo", "0"]
 
-FROM base as deployer-bedrock
-WORKDIR /opt/optimism/packages/contracts-bedrock
-CMD ["yarn", "run", "deploy"]
+#FROM base as deployer-bedrock
+#WORKDIR /opt/optimism/packages/contracts-bedrock
+#CMD ["yarn", "run", "deploy"]
 
 FROM base as data-transport-layer
 WORKDIR /opt/optimism/packages/data-transport-layer


### PR DESCRIPTION
inactivate bedrock build in docker. this might be used in later, so didn't completely remove it.