### PR TITLE
[OR-523] funding amount changed to 20 ETH

### DIFF
--- a/packages/contracts/deploy/016-fund-accounts.ts
+++ b/packages/contracts/deploy/016-fund-accounts.ts
@@ -65,7 +65,7 @@ const deployFn: DeployFunction = async (hre) => {
         )
         // const balance = await wallet.getBalance()
         // const depositAmount = balance.div(2) // Deposit half of the wallet's balance into L2.
-        const depositAmount = hre.ethers.utils.parseEther('10')
+        const depositAmount = hre.ethers.utils.parseEther('20')
         await L1StandardBridge.connect(wallet).depositETH(8_000_000, '0x', {
           value: depositAmount,
           gasLimit: 2_000_000, // Idk, gas estimation was broken and this fixes it.


### PR DESCRIPTION
integration-tests의 fee-payment.spec.ts 에서 트랜잭션 오류가 발생하여 deployer가 L2Wallet에 deposit하는 수량을 10 eth → 20 eth로 수정했습니다.

- [x] 네트워크 실행 확인
- [x] 모든 패키지에서 test 및 lint 확인
- [x] local에서 integration-tests 정상 동작 확인

JIRA: https://onther.atlassian.net/browse/OR-523