### PR TITLE
[OR-574] rename the relayer service

### DIFF
--- a/integration-tests/test/batch-relayer-fast.spec.ts
+++ b/integration-tests/test/batch-relayer-fast.spec.ts
@@ -27,7 +27,7 @@ describe('Batch Relayer Fast Test', async () => {
     L2Message = new Contract(L2MessageAddress, L2MessageJson.abi, env.l2Wallet)
   })
 
-  // Test to send message from L2 to L1 using fast relayer
+  // Test to send message from L2 to L1 using batch relayer fast
   it('should send message from L2 to L1 using the batch relayer fast', async () => {
     const result = await env.waitForXDomainTransactionFast(
       L2Message.sendMessageL2ToL1({ gasLimit: 800000, gasPrice: 0 })
@@ -42,7 +42,7 @@ describe('Batch Relayer Fast Test', async () => {
     expect(decodedData).to.equal('messageFromL2')
   })
 
-  // Test to send multiple message from L2 to L1 using fast relayer
+  // Test to send multiple message from L2 to L1 using batch relayer fast
   it('should send multiple messages from L2 to L1 using the batch relayer fast', async () => {
     // Define the number of times to send the message
     const sendPromises = []

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -127,15 +127,15 @@ services:
       - ${L2GETH_HTTP_PORT:-8545}:8545
       - ${L2GETH_WS_PORT:-8546}:8546
 
-  relayer:
+  batch_relayer:
     depends_on:
       - l1_chain
       - l2geth
     build:
       context: ..
       dockerfile: ./ops/docker/Dockerfile.packages
-      target: tokamak-message-relayer
-    image: onthertech/optimism.message-relayer:${DOCKER_TAG_MESSAGE_RELAYER:-latest}
+      target: tokamak-batch-relayer
+    image: onthertech/optimism.batch-relayer:${DOCKER_TAG_MESSAGE_RELAYER:-latest}
     entrypoint: ./relayer.sh
     environment:
       URL: http://deployer:8081/addresses.json
@@ -150,15 +150,15 @@ services:
       MESSAGE_RELAYER__MULTI_RELAY_LIMIT: 10
       MESSAGE_RELAYER__ENABLE_RELAYER_FILTER: 'false'
 
-  fast_relayer:
+  batch_relayer_fast:
     depends_on:
       - l1_chain
       - l2geth
     build:
       context: ..
       dockerfile: ./ops/docker/Dockerfile.packages
-      target: tokamak-message-relayer-fast
-    image: onthertech/optimism.message-relayer-fast:${DOCKER_TAG_MESSAGE_RELAYER_FAST:-latest}
+      target: tokamak-batch-relayer-fast
+    image: onthertech/optimism.batch-relayer-fast:${DOCKER_TAG_MESSAGE_RELAYER_FAST:-latest}
     entrypoint: ./relayer-fast.sh
     environment:
       URL: http://deployer:8081/addresses.json

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -101,13 +101,13 @@ COPY ./ops/scripts/relayer.sh .
 CMD ["npm", "run", "start"]
 
 
-FROM base as tokamak-message-relayer
+FROM base as tokamak-batch-relayer
 WORKDIR /opt/optimism/packages/tokamak/message-relayer
 COPY ./ops/scripts/relayer.sh .
 CMD ["npm", "run", "start"]
 
 
-FROM base as tokamak-message-relayer-fast
+FROM base as tokamak-batch-relayer-fast
 WORKDIR /opt/optimism/packages/tokamak/message-relayer
 COPY ./ops/scripts/relayer-fast.sh .
 CMD ["npm", "run", "start"]

--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -113,7 +113,7 @@ export class CrossChainMessenger {
   public bedrock: boolean
 
   /**
-   * Whether or not fast relayer is enabled.
+   * Whether or not batch-relayer-fast is enabled.
    */
   public fastRelayer: boolean
 
@@ -598,7 +598,7 @@ export class CrossChainMessenger {
       if (stateRoot === null) {
         return MessageStatus.STATE_ROOT_NOT_PUBLISHED
       } else {
-        // for the fast relayer this should be zero
+        // for the batch-relayer-fast this should be zero
         const challengePeriod = await this.getChallengePeriodSeconds()
         const targetBlock = await this.l1Provider.getBlock(
           stateRoot.batch.blockNumber


### PR DESCRIPTION
# Content

기존 relayer의 서비스 이름 (fast relayer)은 혼동을 줄 수 있어 batch-relay기능을 직관적으로 나타내는 batch-relayer / batch-relayer-fast로 서비스 이름을 변경합니다.

# Jira Ticket
https://onther.atlassian.net/browse/OR-574