### PR TITLE
[OR-588] update dtl to not exit

### DIFF
--- a/packages/data-transport-layer/src/services/l2-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l2-ingestion/service.ts
@@ -108,20 +108,13 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
   }
 
   protected async ensure(): Promise<void> {
-    let retries = 0
     while (true) {
       try {
         await this.state.l2RpcProvider.getNetwork()
         break
       } catch (e) {
-        retries++
-        this.logger.info(`Cannot connect to L2, retrying ${retries}/20`)
-        if (retries >= 20) {
-          this.logger.info('Cannot connect to L2, shutting down')
-          await this.stop()
-          process.exit()
-        }
-        await sleep(1000 * retries)
+        this.logger.info(`Cannot connect to L2, retrying...`)
+        await sleep(5000)
       }
     }
   }


### PR DESCRIPTION
- dtl l2 sync 전에 connection 시도를 20번에서 무제한으로 변경하였습니다.
- 미미한 코드수정이라, 추후 optimism repo 업데이트 시에도 conflict 가 생기지 않을 것으로 추측되어 package 를 바로 업데이트 하였습니다.

감사드립니다.