### PR TITLE
[OR-600] remove multiplatfor build of github action

### DIFF
--- a/.github/workflows/tokamak-public-nightly.yml
+++ b/.github/workflows/tokamak-public-nightly.yml
@@ -36,7 +36,6 @@ jobs:
         with:
           context: .
           file: ./l2geth/Dockerfile
-          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             onthertech/optimism.l2geth:${{ steps.extractver.outputs.GITSHA }}
@@ -73,7 +72,6 @@ jobs:
         with:
           context: .
           file: ./gas-oracle/Dockerfile
-          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             onthertech/optimism.gas-oracle:${{ steps.extractver.outputs.GITSHA }}
@@ -110,7 +108,6 @@ jobs:
         with:
           context: ./ops/docker/hardhat
           file: ./ops/docker/hardhat/Dockerfile
-          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             onthertech/optimism.hardhat-node:${{ steps.extractver.outputs.GITSHA }}
@@ -444,7 +441,6 @@ jobs:
         with:
           context: .
           file: ./proxyd/Dockerfile
-          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             onthertech/optimism.proxyd:${{ steps.extractver.outputs.GITSHA }}
@@ -486,7 +482,6 @@ jobs:
         with:
           context: .
           file: ./op-exporter/Dockerfile
-          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             onthertech/optimism.op-exporter:${{ steps.extractver.outputs.GITSHA }}
@@ -528,7 +523,6 @@ jobs:
         with:
           context: .
           file: ./l2geth-exporter/Dockerfile
-          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             onthertech/optimism.l2geth-exporter:${{ steps.extractver.outputs.GITSHA }}
@@ -569,7 +563,6 @@ jobs:
         with:
           context: .
           file: ./batch-submitter/Dockerfile
-          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             onthertech/optimism.batch-submitter-service:${{ steps.extractver.outputs.GITSHA }}
@@ -607,7 +600,6 @@ jobs:
         with:
           context: .
           file: ./indexer/Dockerfile
-          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             onthertech/optimism.indexer:${{ steps.extractver.outputs.GITSHA }}
@@ -649,7 +641,6 @@ jobs:
         with:
           context: .
           file: ./teleportr/Dockerfile
-          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             onthertech/optimism.teleportr:${{ steps.extractver.outputs.GITSHA }}


### PR DESCRIPTION
개발시 Multi platform 빌드된 이미지를 사용하려고 했으나 개발 머신에서 직접 빌드하고 사용하면 되는 부분이라서 삭제합니다.

ci 때문에 바로 머지합니다..