### PR TITLE
Or 644 modify env log of relayer

### DIFF
--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -120,7 +120,6 @@ services:
       MESSAGE_RELAYER__MAX_WAIT_TIME_S: 5
       MESSAGE_RELAYER__MAX_WAIT_TX_TIME_S: 5
       MESSAGE_RELAYER__MULTI_RELAY_LIMIT: 10
-      MESSAGE_RELAYER__ENABLE_RELAYER_FILTER: 'false'
 
   tokamak-message-relayer-fast:
     depends_on:
@@ -146,7 +145,7 @@ services:
       MESSAGE_RELAYER__MAX_WAIT_TIME_S: 5
       MESSAGE_RELAYER__MAX_WAIT_TX_TIME_S: 5
       MESSAGE_RELAYER__MULTI_RELAY_LIMIT: 10
-      FAST_RELAYER: 'true'
+      MESSAGE_RELAYER__IS_FAST_RELAYER: 'true'
 
   fault_detector:
     depends_on:

--- a/packages/contracts/docs/ICrossDomainMessenger.md
+++ b/packages/contracts/docs/ICrossDomainMessenger.md
@@ -52,7 +52,7 @@ function xDomainMessageSender() external view returns (address)
 ### FailedRelayedFastMessage
 
 ```solidity
-event FailedRelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce, bytes32 indexed msgHash)
+event FailedRelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce)
 ```
 
 
@@ -67,7 +67,6 @@ event FailedRelayedFastMessage(address indexed target, address sender, bytes mes
 | sender  | address | undefined |
 | message  | bytes | undefined |
 | messageNonce  | uint256 | undefined |
-| msgHash `indexed` | bytes32 | undefined |
 
 ### FailedRelayedMessage
 
@@ -88,7 +87,7 @@ event FailedRelayedMessage(bytes32 indexed msgHash)
 ### RelayedFastMessage
 
 ```solidity
-event RelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce, bytes32 indexed msgHash)
+event RelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce)
 ```
 
 
@@ -103,7 +102,6 @@ event RelayedFastMessage(address indexed target, address sender, bytes message, 
 | sender  | address | undefined |
 | message  | bytes | undefined |
 | messageNonce  | uint256 | undefined |
-| msgHash `indexed` | bytes32 | undefined |
 
 ### RelayedMessage
 

--- a/packages/contracts/docs/IL1CrossDomainMessenger.md
+++ b/packages/contracts/docs/IL1CrossDomainMessenger.md
@@ -109,7 +109,7 @@ function xDomainMessageSender() external view returns (address)
 ### FailedRelayedFastMessage
 
 ```solidity
-event FailedRelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce, bytes32 indexed msgHash)
+event FailedRelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce)
 ```
 
 
@@ -124,7 +124,6 @@ event FailedRelayedFastMessage(address indexed target, address sender, bytes mes
 | sender  | address | undefined |
 | message  | bytes | undefined |
 | messageNonce  | uint256 | undefined |
-| msgHash `indexed` | bytes32 | undefined |
 
 ### FailedRelayedMessage
 
@@ -145,7 +144,7 @@ event FailedRelayedMessage(bytes32 indexed msgHash)
 ### RelayedFastMessage
 
 ```solidity
-event RelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce, bytes32 indexed msgHash)
+event RelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce)
 ```
 
 
@@ -160,7 +159,6 @@ event RelayedFastMessage(address indexed target, address sender, bytes message, 
 | sender  | address | undefined |
 | message  | bytes | undefined |
 | messageNonce  | uint256 | undefined |
-| msgHash `indexed` | bytes32 | undefined |
 
 ### RelayedMessage
 

--- a/packages/contracts/docs/IL2CrossDomainMessenger.md
+++ b/packages/contracts/docs/IL2CrossDomainMessenger.md
@@ -71,7 +71,7 @@ function xDomainMessageSender() external view returns (address)
 ### FailedRelayedFastMessage
 
 ```solidity
-event FailedRelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce, bytes32 indexed msgHash)
+event FailedRelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce)
 ```
 
 
@@ -86,7 +86,6 @@ event FailedRelayedFastMessage(address indexed target, address sender, bytes mes
 | sender  | address | undefined |
 | message  | bytes | undefined |
 | messageNonce  | uint256 | undefined |
-| msgHash `indexed` | bytes32 | undefined |
 
 ### FailedRelayedMessage
 
@@ -107,7 +106,7 @@ event FailedRelayedMessage(bytes32 indexed msgHash)
 ### RelayedFastMessage
 
 ```solidity
-event RelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce, bytes32 indexed msgHash)
+event RelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce)
 ```
 
 
@@ -122,7 +121,6 @@ event RelayedFastMessage(address indexed target, address sender, bytes message, 
 | sender  | address | undefined |
 | message  | bytes | undefined |
 | messageNonce  | uint256 | undefined |
-| msgHash `indexed` | bytes32 | undefined |
 
 ### RelayedMessage
 

--- a/packages/contracts/docs/L1CrossDomainMessenger.md
+++ b/packages/contracts/docs/L1CrossDomainMessenger.md
@@ -356,7 +356,7 @@ function xDomainMessageSender() external view returns (address)
 ### FailedRelayedFastMessage
 
 ```solidity
-event FailedRelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce, bytes32 indexed msgHash)
+event FailedRelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce)
 ```
 
 
@@ -371,7 +371,6 @@ event FailedRelayedFastMessage(address indexed target, address sender, bytes mes
 | sender  | address | undefined |
 | message  | bytes | undefined |
 | messageNonce  | uint256 | undefined |
-| msgHash `indexed` | bytes32 | undefined |
 
 ### FailedRelayedMessage
 
@@ -473,7 +472,7 @@ event Paused(address account)
 ### RelayedFastMessage
 
 ```solidity
-event RelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce, bytes32 indexed msgHash)
+event RelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce)
 ```
 
 
@@ -488,7 +487,6 @@ event RelayedFastMessage(address indexed target, address sender, bytes message, 
 | sender  | address | undefined |
 | message  | bytes | undefined |
 | messageNonce  | uint256 | undefined |
-| msgHash `indexed` | bytes32 | undefined |
 
 ### RelayedMessage
 

--- a/packages/contracts/docs/L1CrossDomainMessengerFast.md
+++ b/packages/contracts/docs/L1CrossDomainMessengerFast.md
@@ -367,7 +367,7 @@ function xDomainMessageSender() external view returns (address)
 ### FailedRelayedFastMessage
 
 ```solidity
-event FailedRelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce, bytes32 indexed msgHash)
+event FailedRelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce)
 ```
 
 
@@ -382,7 +382,6 @@ event FailedRelayedFastMessage(address indexed target, address sender, bytes mes
 | sender  | address | undefined |
 | message  | bytes | undefined |
 | messageNonce  | uint256 | undefined |
-| msgHash `indexed` | bytes32 | undefined |
 
 ### FailedRelayedMessage
 
@@ -484,7 +483,7 @@ event Paused(address account)
 ### RelayedFastMessage
 
 ```solidity
-event RelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce, bytes32 indexed msgHash)
+event RelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce)
 ```
 
 
@@ -499,7 +498,6 @@ event RelayedFastMessage(address indexed target, address sender, bytes message, 
 | sender  | address | undefined |
 | message  | bytes | undefined |
 | messageNonce  | uint256 | undefined |
-| msgHash `indexed` | bytes32 | undefined |
 
 ### RelayedMessage
 

--- a/packages/contracts/docs/L2CrossDomainMessenger.md
+++ b/packages/contracts/docs/L2CrossDomainMessenger.md
@@ -171,7 +171,7 @@ function xDomainMessageSender() external view returns (address)
 ### FailedRelayedFastMessage
 
 ```solidity
-event FailedRelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce, bytes32 indexed msgHash)
+event FailedRelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce)
 ```
 
 
@@ -186,7 +186,6 @@ event FailedRelayedFastMessage(address indexed target, address sender, bytes mes
 | sender  | address | undefined |
 | message  | bytes | undefined |
 | messageNonce  | uint256 | undefined |
-| msgHash `indexed` | bytes32 | undefined |
 
 ### FailedRelayedMessage
 
@@ -207,7 +206,7 @@ event FailedRelayedMessage(bytes32 indexed msgHash)
 ### RelayedFastMessage
 
 ```solidity
-event RelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce, bytes32 indexed msgHash)
+event RelayedFastMessage(address indexed target, address sender, bytes message, uint256 messageNonce)
 ```
 
 
@@ -222,7 +221,6 @@ event RelayedFastMessage(address indexed target, address sender, bytes message, 
 | sender  | address | undefined |
 | message  | bytes | undefined |
 | messageNonce  | uint256 | undefined |
-| msgHash `indexed` | bytes32 | undefined |
 
 ### RelayedMessage
 

--- a/packages/tokamak/message-relayer/package.json
+++ b/packages/tokamak/message-relayer/package.json
@@ -36,7 +36,6 @@
     "@eth-optimism/core-utils": "0.10.1",
     "@eth-optimism/ynatm": "^0.2.2",
     "@tokamak-optimism/sdk": "0.0.1",
-    "dotenv": "^8.2.0",
     "ethers": "^5.7.0"
   },
   "devDependencies": {

--- a/packages/tokamak/message-relayer/package.json
+++ b/packages/tokamak/message-relayer/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@tokamak-optimism/message-relayer",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "[Optimism] Service for automatically relaying L2 to L1 transactions",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/tokamak/message-relayer/src/service.ts
+++ b/packages/tokamak/message-relayer/src/service.ts
@@ -18,8 +18,6 @@ import {
 } from '@tokamak-optimism/sdk'
 import { Provider } from '@ethersproject/abstract-provider'
 
-import 'dotenv/config'
-
 type MessageRelayerOptions = {
   l1RpcProvider: Provider
   l2RpcProvider: Provider
@@ -184,9 +182,6 @@ export class MessageRelayerService extends BaseServiceV2<
   }
 
   protected async init(): Promise<void> {
-    if (process.env.FAST_RELAYER) {
-      this.options.isFastRelayer = true
-    }
     // check options
     this.logger.info('Initializing message relayer', {
       fromL2TransactionIndex: this.options.fromL2TransactionIndex,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7080,11 +7080,6 @@ dotenv@^16.0.0:
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz"
   integrity sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==
 
-dotenv@^8.2.0:
-  version "8.6.0"
-  resolved "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz"
-  integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
-
 dotignore@~0.1.2:
   version "0.1.2"
   resolved "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz"


### PR DESCRIPTION
@tokamak-optimism/message-relayer의 환경 변수/로그를 수정하고 버전을 v0.5.5 -> v0.5.6으로 변경하였습니다.

* FAST_RELAYER > MESSAGE__RELAYER__FAST_RELAYER로 환경 변수 이름 수정
* dotenv 삭제
* 불필요한 log 삭제 및 log 라이브러리 적용
* 패키지 버전 변경: v0.5.5 → v0.5.6