### PR TITLE
[OR-655] Change position to show tx sent log

### DIFF
--- a/packages/tokamak/message-relayer/package.json
+++ b/packages/tokamak/message-relayer/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@tokamak-optimism/message-relayer",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "[Optimism] Service for automatically relaying L2 to L1 transactions",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/tokamak/message-relayer/src/service.ts
+++ b/packages/tokamak/message-relayer/src/service.ts
@@ -381,6 +381,9 @@ export class MessageRelayerService extends BaseServiceV2<
                     nonce,
                   },
                 })
+              this.logger.info(
+                `Relay message transaction sent, txid: ${txResponse.hash}`
+              )
               const txReceipt = await txResponse.wait(
                 this.options.numConfirmations
               )
@@ -403,9 +406,6 @@ export class MessageRelayerService extends BaseServiceV2<
                 ),
                 delay: this.options.resubmissionTimeout,
               })
-              this.logger.info(
-                `Relay message transaction sent, txid: ${receipt.transactionHash}`
-              )
               this.metrics.numBatchTx.inc()
               this.metrics.numRelayedMessages.inc(subBuffer.length)
             } catch (err) {


### PR DESCRIPTION
Tx를 receipt를 받아오고 찍으면 블록이 생성될때까지 기다리게 되고 오류시 확인할 수가 없기때문에 tx 전송후 바로 찍게했습니다.