### PR TITLE
[OR-695] Add logs for manual deployment

### DIFF
--- a/packages/contracts/deploy/017-OVM_L1StandardBridge.deploy.ts
+++ b/packages/contracts/deploy/017-OVM_L1StandardBridge.deploy.ts
@@ -114,7 +114,15 @@ const deployFn: DeployFunction = async (hre) => {
 
   // Set the addresses!
   console.log('Ownership successfully transferred. Invoking doActions...')
-  await ChugSplashDictator.doActions(bridgeCode)
+  console.log('--- L1StandardBridge Bytecode ---')
+  console.log(bridgeCode)
+  console.log('---')
+  const res = await ChugSplashDictator.doActions(bridgeCode)
+  console.log(`Check transaction was failed: ${res.hash}`)
+  console.log(
+    'If the tx was failed, please execute doActions method of ChugSplashDictator.'
+  )
+  console.log(`ChugSplashDictator.address: ${ChugSplashDictator.address}`)
 
   console.log(`Confirming that owner address was correctly set...`)
   await awaitCondition(


### PR DESCRIPTION
doActions할 경우에 out of gas가 나올때가 있습니다.
이때에는 bytecode를 직접 넣어주어야합니다.

